### PR TITLE
fix: Move config files from git to storage

### DIFF
--- a/setup_openvpn.sh
+++ b/setup_openvpn.sh
@@ -39,7 +39,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # Install OpenVPN and Easy-RSA
 install_dependencies() {
     apt-get update
-    apt-get install -y openvpn easy-rsa apt-transport-https ca-certificates gnupg curl
+    apt-get install -y openvpn easy-rsa
 
     if ! command -v gsutil &> /dev/null; then
         echo "gsutil not found, installing Google Cloud SDK..."

--- a/terraform/instances/instance.tf
+++ b/terraform/instances/instance.tf
@@ -34,6 +34,11 @@ variable "bucket_name" {
   description = "The bucket name used to store ovpn files"
 }
 
+variable "objects" {
+  type = list(string)
+  description = "The objects to pull from storage during startup"
+}
+
 resource "google_compute_instance" "openvpn_instance" {
   name         = var.instance_name
   machine_type = "e2-medium"
@@ -65,10 +70,17 @@ resource "google_compute_instance" "openvpn_instance" {
     runcmd:
       - |
         if [ ! -f /var/log/first-boot.log ]; then
+          #install gsutil
           sudo apt update
-          sudo apt install -y git
-          sudo git clone https://github.com/mkmad/open-vpn.git /home/$(whoami)/open-vpn
+          sudo apt install -y apt-transport-https ca-certificates gnupg curl
+          curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg
+          echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
+          sudo apt-get update && sudo apt-get install -y google-cloud-cli
+
           cd /home/$(whoami)/open-vpn
+          %{ for obj in var.objects }
+          gsutil cp gs://${var.bucket_name}/${obj} ${obj}
+          %{ endfor }
           sudo chmod +x setup_openvpn.sh
           sudo ./setup_openvpn.sh --clients 3 --server_ip ${var.static_ip} --server_port ${var.instance_port} --bucket_name ${var.bucket_name}
           sudo touch /var/log/first-boot.log

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -19,6 +19,24 @@ module "storage" {
   region                = var.region
   service_account_email = module.service_account.email
   bucket_name           = var.bucket_name
+  objects = [ 
+    {
+      name = "setup_openvpn.sh"
+      content = file("${path.root}/../setup_openvpn.sh")
+    },
+    {
+      name = "server.conf"
+      content = file("${path.root}/../server.conf")
+    },
+    {
+      name = "client.conf"
+      content = file("${path.root}/../client.conf")
+    },
+    {
+      name = "vars"
+      content = file("${path.root}/../vars")
+    }
+   ]
 }
 
 module "instance" {
@@ -32,4 +50,10 @@ module "instance" {
   instance_name         = var.instance_name
   instance_port         = var.instance_port
   bucket_name           = module.storage.bucket_name
+  objects = [ 
+    "setup_openvpn.sh",
+    "server.conf",
+    "client.conf",
+    "vars",
+   ]
 }

--- a/terraform/storage/storage.tf
+++ b/terraform/storage/storage.tf
@@ -14,6 +14,14 @@ variable "bucket_name" {
   description = "The bucket name used to store ovpn files"
 }
 
+variable "objects" {
+  type = list(object({
+    name = string,
+    content = string,
+  }))
+  description = "The ovpn files objects."
+}
+
 resource "google_storage_bucket" "openvpn_bucket" {
   name     = "${var.bucket_name}-${var.project_id}"
   location = var.region
@@ -29,6 +37,13 @@ resource "google_storage_bucket_iam_member" "bucket_reader" {
   bucket = google_storage_bucket.openvpn_bucket.name
   role   = "roles/storage.objectViewer"
   member = "serviceAccount:${var.service_account_email}"
+}
+
+resource "google_storage_bucket_object" "openvpn_objects" {
+  for_each = {for index, obj in var.objects : obj.name => obj }
+  bucket = google_storage_bucket.openvpn_bucket.name
+  name = each.value.name
+  content = each.value.content
 }
 
 output "bucket_name" {


### PR DESCRIPTION
Considering we may end up using our own repository, which is monorepo, we don't want to clone whole repository into openvpn instance because of efficiency and security.

Didn't test this setup tho, it'd be helpful if you can test this.